### PR TITLE
cmds: oplus-alert-slider: Change method ID

### DIFF
--- a/cmds/oplus-alert-slider.cpp
+++ b/cmds/oplus-alert-slider.cpp
@@ -44,11 +44,11 @@ int main() {
         }
         printf("State %d\n", read_tristate());
         if(state == 1) {
-            system("service call audio 32 i32 0 s16 android");
+            system("service call audio 36 i32 0 s16 android");
         } else if(state == 2) {
-            system("service call audio 32 i32 1 s16 android");
+            system("service call audio 36 i32 1 s16 android");
         } else if(state == 3) {
-            system("service call audio 32 i32 2 s16 android");
+            system("service call audio 36 i32 2 s16 android");
         }
     }
 }


### PR DESCRIPTION
* Android 13 uses 36 instead of 32.
* Tested on OnePlus Nord 2 5G, running Android 13.

Change-Id: Ifabe2aa221feac3c14b2f8dbbfc72e72534f7d53