### PR TITLE
overlay: Set config_displayLightSensorType to android.sensor.light

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -52,4 +52,5 @@
 	    <item>me.phh.treble.app</item>
     </string-array>
 
+    <string name="config_displayLightSensorType" translatable="false">android.sensor.light</string>
 </resources>


### PR DESCRIPTION
The fallback was broken in frameworks/base@4be1126d2591.

Credits: https://github.com/LineageOS/android_vendor_lineage/commit/f8663e248428c573b01d1178ed4f025a47962c5f