### PR TITLE
Set default the Bluetooth class of device

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -15,6 +15,16 @@ ro.boot.realme.lockstate=0
 #Fixes fingerprint unlock delay
 persist.wm.enable_remote_keyguard_animation=0
 
+# Set the Bluetooth Class of Device
+# Service Field: 0x5A -> 90
+#    Bit 17: Networking
+#    Bit 19: Capturing
+#    Bit 20: Object Transfer
+#    Bit 22: Telephony
+# MAJOR_CLASS: 0x02 -> 2 (Phone)
+# MINOR_CLASS: 0x0C -> 12 (Smart Phone)
+bluetooth.device.class_of_device=90,2,12
+
 # Enable system-side generic bluetooth audio HAL
 persist.bluetooth.system_audio_hal.enabled=1
 # Set commonly-supported Bluetooth profiles to enabled


### PR DESCRIPTION
The class of device is a string with a list of uint8t values: 90,2,12

The meaning is as follows:
{Service Field, Major class, Minor class}

Service Field: 0x5A -> 90
    Bit 17: Networking
    Bit 19: Capturing
    Bit 20: Object Transfer
    Bit 22: Telephony
MAJOR_CLASS: 0x02 -> 2 (Phone)
MINOR_CLASS: 0x0C -> 12 (Smart Phone)

Bug: 217452259
Test: make -j; -- check that bluetooth.device.class_of_device is correct

Change-Id: I24fd57bacbf6786a26f7079e7a6e9857dbe170d1