### PR TITLE
add support of kirin710 model (huawei)

### DIFF
--- a/vndk-detect
+++ b/vndk-detect
@@ -16,11 +16,11 @@ if [ -d /sys/module/five ];then
 elif [ -f /sbin/adbd ];then
 	mount -o bind /system/bin/adbd /sbin/adbd
 fi
-if ( getprop ro.hardware | grep -qE '(kirin970|hi3660|hi6250|hi3670)' );then
+if ( getprop ro.hardware | grep -qE '(kirin710|kirin970|hi3660|hi6250|hi3670)' );then
 	FOUND_HUAWEI=1
 fi
 
-if getprop ro.vendor.build.fingerprint |grep -qiE '(huawei|honor|hi3660)';then
+if getprop ro.vendor.build.fingerprint |grep -qiE '(huawei|honor|kirin710|kirin970|hi3660|hi6250|hi3670)';then
 	FOUND_HUAWEI=1
 fi
 


### PR DESCRIPTION
From the erofs support under android13, it is possible to start gsi with kirin 710 processors (p smart 2019, 2020 for example). This pull request allows all kirin 710 models to be recognized as huawei brand phones.