### PR TITLE
treble: Add support for LED belts on Unihertz Luna

### DIFF
--- a/sepolicy/hal_aguiledbelt_hwservice.te
+++ b/sepolicy/hal_aguiledbelt_hwservice.te
@@ -1,0 +1,4 @@
+type hal_aguiledbelt_hwservice, hwservice_manager_type;
+allow system_app hal_aguiledbelt_hwservice:hwservice_manager { find };
+type hal_aguiledbelt, domain;
+allow system_app hal_aguiledbelt:binder { call };


### PR DESCRIPTION
via system apps (currently, https://gitea.angry.im/PeterCxy/Lunatic). This commits adds corresponding SELinux rules for access.