### PR TITLE
remove-telephony: only remount system

### DIFF
--- a/remove-telephony.sh
+++ b/remove-telephony.sh
@@ -2,7 +2,7 @@
 
 mount -o remount,rw /
 mount -o remount,rw /system
-remount
+remount system
 
 rm -Rf /system/priv-app/TeleService
 mount -o remount,ro /


### PR DESCRIPTION
a full `remount` might brick some devices