### PR TITLE
Add an option to disable 'ro.telephony.block_binder_thread_on_incoming_calls'

### DIFF
--- a/phh-prop-handler.sh
+++ b/phh-prop-handler.sh
@@ -79,10 +79,12 @@ if [ "$1" == "persist.sys.phh.asus.dt2w" ]; then
     else
         setprop persist.asus.dclick 0
     fi
+    exit
 fi
 
 if [ "$1" == "persist.sys.phh.asus.usb.port" ]; then
         setprop persist.vendor.usb.controller.default "$prop_value"
+    exit
 fi
 
 if [ "$1" == "persist.sys.phh.xiaomi.dt2w" ]; then

--- a/phh-prop-handler.sh
+++ b/phh-prop-handler.sh
@@ -127,6 +127,19 @@ if [ "$1" == "persist.sys.phh.oppo.usbotg" ]; then
     exit
 fi
 
+if [ "$1" == "persist.sys.phh.allow_binder_thread_on_incoming_calls" ]; then
+    if [[ "$prop_value" != "0" && "$prop_value" != "1" ]]; then
+        exit 1
+    fi
+
+    if [[ "$prop_value" == 1 ]];then
+        resetprop_phh ro.telephony.block_binder_thread_on_incoming_calls false
+    else
+        resetprop_phh --delete ro.telephony.block_binder_thread_on_incoming_calls
+    fi
+    exit
+fi
+
 if [ "$1" == "persist.sys.phh.disable_audio_effects" ];then
     if [[ "$prop_value" != "0" && "$prop_value" != "1" ]]; then
         exit 1

--- a/vndk.rc
+++ b/vndk.rc
@@ -40,6 +40,9 @@ on property:persist.sys.phh.oppo.usbotg=*
 on property:persist.sys.phh.xiaomi.dt2w=*
     exec u:r:phhsu_daemon:s0 root -- /system/bin/phh-prop-handler.sh "persist.sys.phh.xiaomi.dt2w"
 
+on property:persist.sys.phh.allow_binder_thread_on_incoming_calls=*
+    exec u:r:phhsu_daemon:s0 root -- /system/bin/phh-prop-handler.sh "persist.sys.phh.allow_binder_thread_on_incoming_calls"
+
 on property:persist.sys.phh.disable_audio_effects=*
     exec u:r:phhsu_daemon:s0 root -- /system/bin/phh-prop-handler.sh "persist.sys.phh.disable_audio_effects"
 


### PR DESCRIPTION
* It is required to set to false on some devices to fix incoming calls when 4G calling is enabled.
* Tested on Rog Phone 1.
* Also, add the missing exit call for asus features.