### PR TITLE
Always set 'sys.usb.all_controllers' for Asus usb port picker

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -975,9 +975,8 @@ if getprop ro.vendor.build.fingerprint |grep -qiE -e ASUS_I006D -e ASUS_I003;the
 	setprop persist.sys.phh.fod.asus true
 fi
 
-if getprop ro.vendor.build.fingerprint | grep -qE 'asus/'; then
-    setprop sys.usb.all_controllers "$(ls /sys/class/udc |tr ' ' ',')"
-fi
+# For Asus usb port picker
+setprop sys.usb.all_controllers "$(ls /sys/class/udc |tr ' ' ',')"
 
 if (getprop ro.vendor.build.fingerprint;getprop ro.odm.build.fingerprint) |grep -qiE '^oneplus/' ||
 	getprop ro.build.overlay.deviceid |grep -qiE -e '^RMX' -e '^CPH' ||


### PR DESCRIPTION
On Rog Phone 1, the build fingerprint doesn't seem to be ready when rw-system.sh is executed. To work around this, set the prop using phh-prop-hander.sh when the Asus settings got enabled.