### PR TITLE
Fix Samsung Fingerprint detection

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -372,7 +372,7 @@ if grep vendor.huawei.hardware.biometrics.fingerprint /vendor/manifest.xml; then
 fi
 
 foundFingerprint=false
-for manifest in /vendor/manifest.xml /vendor/etc/vintf /odm/etc/vintf;do
+for manifest in /vendor/manifest.xml /vendor/etc/vintf/manifest.xml /odm/etc/vintf;do
 	if grep -q \
 		-e android.hardware.biometrics.fingerprint \
 		-e vendor.oppo.hardware.biometrics.fingerprint \


### PR DESCRIPTION

Maybe in /odm/etc/vintf is too manifest.xml too? i don't have this folder in my Samsung.

