### PR TITLE
sysbta: Don't delete A2DP props while disabling

### DIFF
--- a/phh-prop-handler.sh
+++ b/phh-prop-handler.sh
@@ -251,8 +251,8 @@ if [ "$1" == "persist.bluetooth.system_audio_hal.enabled" ]; then
         resetprop_phh ro.bluetooth.a2dp_offload.supported false
     else
         resetprop_phh --delete persist.bluetooth.bluetooth_audio_hal.disabled
-        resetprop_phh --delete persist.bluetooth.a2dp_offload.disabled
-        resetprop_phh --delete ro.bluetooth.a2dp_offload.supported
+        resetprop_phh persist.bluetooth.a2dp_offload.disabled
+        resetprop_phh ro.bluetooth.a2dp_offload.supported
     fi
     restartAudio
     exit


### PR DESCRIPTION
Reset thems to their declared state to avoid a reboot, toggling Bluetooth is enough to get the changes.  Vendor side A2DP implementation exist somewhere