### PR TITLE
Fix Vibration Motor permissions for Tecno Pova 4 Pro

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1165,5 +1165,5 @@ fi
 # Fixes Vibrator on TECNO POVA 4 Pro
 
 if getprop ro.product.vendor.device | grep -q -e TECNO-LG8n; then
-  chown -R system:system /sys/class/leds/vibrator_single/
+    chown -R system:system /sys/class/leds/vibrator_single/
 fi

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1161,3 +1161,9 @@ if getprop ro.boot.hardware.sku | grep -q -e taoyao -e cupid -e daumier; then
 
     setprop persist.phh.xiaomi.fod.enrollment.id 10
 fi
+
+# Fixes Vibrator on TECNO POVA 4 Pro
+
+if getprop ro.product.vendor.device | grep -q -e TECNO-LG8n; then
+  chown -R system:system /sys/class/leds/vibrator_single/
+fi


### PR DESCRIPTION
This should fix vibration motor not working on Tecno Pova 4 Pro