### PR TITLE
Fix low brightness issue on Infinix Note 30

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1202,3 +1202,8 @@ resetprop_phh ro.config.media_vol_default 8
 if getprop ro.vendor.build.fingerprint | grep -iq -e xiaomi/renoir; then
     resetprop_phh ro.vendor.sre.enable false
 fi
+
+# Fix low brightness issue on Infinix Note 30
+if getprop ro.vendor.build.fingerprint | grep -iq -e infinix/x6833b; then
+  setprop ro.vendor.transsion.backlight_hal.optimization 1
+fi


### PR DESCRIPTION
Fixes low brightness issue on Infinix Note 30, which seems to be oddly specific to this phone model only and not the Pro variant (probably due to the screen being IPS and AMOLED on the Pro variant?)