### PR TITLE
Also fix Brightness for TECNO POVA 4(LG7n) and TECNO POVA 5(LH7n)

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1203,7 +1203,7 @@ if getprop ro.vendor.build.fingerprint | grep -iq -e xiaomi/renoir; then
     resetprop_phh ro.vendor.sre.enable false
 fi
 
-# Fix low brightness issue on Infinix Note 30
-if getprop ro.vendor.build.fingerprint | grep -iq -e infinix/x6833b; then
+# Fix low brightness issue on Infinix Note 30 and TECNO POVA 4 non-Pro
+if getprop ro.vendor.build.fingerprint | grep -iq -e infinix/x6833b -e tecno/lg7n -e tecno/lh7n; then
   setprop ro.vendor.transsion.backlight_hal.optimization 1
 fi


### PR DESCRIPTION
Infinix Note 30 and the mentioned devices above uses the same prop for LCD brightness fix

Tested by converting an existing GSI to rw and replacing it's /system/bin/rw-system.sh with my modified version

This piggybacks from commit 3a4b2ee