### PR TITLE
[OBSELETE] Make brightness fix work for all newer Transsion non-AMOLED devices

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1202,10 +1202,11 @@ if getprop ro.vendor.build.fingerprint | grep -iq -e xiaomi/renoir; then
     resetprop_phh ro.vendor.sre.enable false
 fi
 
-# Fix dim brightness issue on Infinix Note 30, TECNO POVA 4 non-Pro and TECNO POVA 5
-if getprop ro.vendor.build.fingerprint | grep -iq -e infinix/x6833b -e tecno/lg7n -e tecno/lh7n -e tecno/lf7-gl; then
-  setprop ro.vendor.transsion.backlight_hal.optimization 1
-fi
+# Fix dim brightness issue on newer Transsion devices with LCD screen
+case "$(getprop ro.vendor.transsion.backlight_12bit)" in
+    1|true)
+        setprop ro.vendor.transsion.backlight_hal.optimization 1
+esac
 
 # brightness fix for platform ums512 And ums9230
 if getprop ro.board.platform |grep -iq -e ums512 -e ums9230;then

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1202,11 +1202,10 @@ if getprop ro.vendor.build.fingerprint | grep -iq -e xiaomi/renoir; then
     resetprop_phh ro.vendor.sre.enable false
 fi
 
-# Fix dim brightness issue on newer Transsion devices with LCD screen
-case "$(getprop ro.vendor.transsion.backlight_12bit)" in
-    1|true)
-        setprop ro.vendor.transsion.backlight_hal.optimization 1
-esac
+# Fix dim brightness issue on newer Transsion non-AMOLED devices
+if [ -n "$(getprop ro.vendor.transsion.backlight_12bit)" ]; then
+    setprop ro.vendor.transsion.backlight_hal.optimization "$(getprop ro.vendor.transsion.backlight_12bit)"
+fi
 
 # brightness fix for platform ums512 And ums9230
 if getprop ro.board.platform |grep -iq -e ums512 -e ums9230;then


### PR DESCRIPTION
I found out that there are more Transsion devices (TECNO, Infinix, & Itel) that uses this prop and I had suspected that it has something to do with those devices using non-AMOLED panel (mostly LCD). So I did a few research using firmware dumps and my suspicion was right. Then I lookup at related prop that is defined in /vendor, and found that `ro.vendor.transsion.backlight_12bit` is also set on those non-AMOLED devices.

So this patch will theoretically make the fix work on all non-AMOLED devices and we don't need to specifically check certain models to do it.