### PR TITLE
Make brightness fix work for all non-AMOLED Transsion devices

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1202,9 +1202,11 @@ if getprop ro.vendor.build.fingerprint | grep -iq -e xiaomi/renoir; then
     resetprop_phh ro.vendor.sre.enable false
 fi
 
-# Fix dim brightness issue on Infinix Note 30, TECNO POVA 4 non-Pro and TECNO POVA 5
-if getprop ro.vendor.build.fingerprint | grep -iq -e infinix/x6833b -e tecno/lg7n -e tecno/lh7n -e tecno/lf7-gl; then
-  setprop ro.vendor.transsion.backlight_hal.optimization 1
+# brightness fix for platform ums512 And ums9230
+if getprop ro.board.platform |grep -iq -e ums512 -e ums9230;then
+    setprop persist.sys.qcom-brightness "$(cat /sys/class/backlight/sprd_backlight/max_brightness)"
+fi
+endor.transsion.backlight_hal.optimization 1
 fi
 
 # brightness fix for platform ums512 And ums9230

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1206,8 +1206,6 @@ fi
 if getprop ro.board.platform |grep -iq -e ums512 -e ums9230;then
     setprop persist.sys.qcom-brightness "$(cat /sys/class/backlight/sprd_backlight/max_brightness)"
 fi
-endor.transsion.backlight_hal.optimization 1
-fi
 
 # brightness fix for platform ums512 And ums9230
 if getprop ro.board.platform |grep -iq -e ums512 -e ums9230;then

--- a/vndk.rc
+++ b/vndk.rc
@@ -112,4 +112,3 @@ service watchdogd-gsi /system/bin/watchdogd 10 20
 # Fix for non-AMOLED Transsion devices where brightness would be dimmer than usual
 on property:ro.vendor.transsion.backlight_12bit=*
     setprop ro.vendor.transsion.backlight_hal.optimization ${ro.vendor.transsion.backlight_12bit}
-it}

--- a/vndk.rc
+++ b/vndk.rc
@@ -1,14 +1,14 @@
 on post-fs
-	exec - root -- /system/bin/vndk-detect
-	exec - root -- /system/bin/rw-system.sh
-	mount none /system/etc/usb_audio_policy_configuration.xml /vendor/etc/usb_audio_policy_configuration.xml bind
-        setprop ro.vndk.version ${persist.sys.vndk}
+    exec - root -- /system/bin/vndk-detect
+    exec - root -- /system/bin/rw-system.sh
+    mount none /system/etc/usb_audio_policy_configuration.xml /vendor/etc/usb_audio_policy_configuration.xml bind
+    setprop ro.vndk.version ${persist.sys.vndk}
 
 on property:vold.decrypt=trigger_restart_framework
-	exec - root -- /system/bin/phh-on-data.sh
+    exec - root -- /system/bin/phh-on-data.sh
 
 on early-boot
-	exec - root -- /system/bin/phh-on-data.sh
+    exec - root -- /system/bin/phh-on-data.sh
 
 service phh_on_boot /system/bin/phh-on-boot.sh
     oneshot
@@ -95,16 +95,21 @@ on property:persist.sys.phh.force_display_5g=1
     exec u:r:phhsu_daemon:s0 root -- /system/bin/resetprop_phh ro.telephony.default_network 33,33
 
 on property:persist.sys.phh.ims.floss=true
-   exec u:r:phhsu_daemon:s0 root -- /system/bin/resetprop_phh ro.telephony.iwlan_operation_mode AP-assisted
+    exec u:r:phhsu_daemon:s0 root -- /system/bin/resetprop_phh ro.telephony.iwlan_operation_mode AP-assisted
 
 on property:persist.sys.phh.enable_sf_gl_backpressure=*
-   setprop debug.sf.enable_gl_backpressure ${persist.sys.phh.enable_sf_gl_backpressure}
+    setprop debug.sf.enable_gl_backpressure ${persist.sys.phh.enable_sf_gl_backpressure}
 
 on property:persist.sys.phh.dynamic_fps=*
-   setprop ro.surface_flinger.use_content_detection_for_refresh_rate ${persist.sys.phh.dynamic_fps}
+    setprop ro.surface_flinger.use_content_detection_for_refresh_rate ${persist.sys.phh.dynamic_fps}
 
 # Set watchdog timer to 30 seconds and pet it every 10 seconds to get a 20 second margin
 service watchdogd-gsi /system/bin/watchdogd 10 20
     class core
     oneshot
     seclabel u:r:watchdogd:s0
+
+# Fix for non-AMOLED Transsion devices where brightness would be dimmer than usual
+on property:ro.vendor.transsion.backlight_12bit=*
+    setprop ro.vendor.transsion.backlight_hal.optimization ${ro.vendor.transsion.backlight_12bit}
+it}


### PR DESCRIPTION
Previously the brightness fix was only for specific models and we would need to manually specify the device. But with this patch, we will no longer need to do it since we can just check if `ro.vendor.transsion.backlight_12bit` exists and inherit the value.

Background: I noticed that more Transsion devices are affected by the dimmer brightness issue other than my Infinix Note 30, so I did some research and found out that `ro.vendor.transsion.backlight_12bit` always coexists with `ro.vendor.transsion.backlight_hal.optimization` on non-AMOLED variant of the devices. This patch will make use of the former prop to set the latter prop with the same value.