### PR TITLE
rw-system: undo duplicate code replacing existing code

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1208,9 +1208,9 @@ if getprop ro.vendor.build.fingerprint | grep -iq -e xiaomi/renoir; then
     resetprop_phh ro.vendor.sre.enable false
 fi
 
-# brightness fix for platform ums512 And ums9230
-if getprop ro.board.platform |grep -iq -e ums512 -e ums9230;then
-    setprop persist.sys.qcom-brightness "$(cat /sys/class/backlight/sprd_backlight/max_brightness)"
+# Fix dim brightness issue on Infinix Note 30, TECNO POVA 4 non-Pro and TECNO POVA 5
+if getprop ro.vendor.build.fingerprint | grep -iq -e infinix/x6833b -e tecno/lg7n -e tecno/lh7n -e tecno/lf7-gl; then
+  setprop ro.vendor.transsion.backlight_hal.optimization 1
 fi
 
 # brightness fix for platform ums512 And ums9230


### PR DESCRIPTION
A recent PR duplicated code that already existed and overwrote other necessary code in the process, revert it to bring back the existing brightness fix for some other devices.