### PR TITLE
cmds: Support Xiaomi Smart Pen force enable in xiaomi-touch ioctl

### DIFF
--- a/cmds/xiaomi-touch.cpp
+++ b/cmds/xiaomi-touch.cpp
@@ -25,22 +25,23 @@
 #define Touch_Nonui_Mode 17
 #define Touch_Debug_Level 18
 #define Touch_Power_Status 19
-#define Touch_Mode_NUM 20
+#define Touch_Pen_ENABLE 20
+#define Touch_Mode_NUM 21
 
 #define TOUCH_DEV_PATH "/dev/xiaomi-touch"
 #define TOUCH_ID 0
 #define TOUCH_MAGIC 0x5400
 #define TOUCH_IOC_SETMODE TOUCH_MAGIC + SET_CUR_VALUE
 
-int main(int argc, char **argv) {
-    if(argc != 3) {
-        fprintf(stderr, "Usage: %s <mode> <0|1>\n", argv[0]);
+int main(int argc, char **argv)
+{
+    if (argc != 3) {
+        fprintf(stderr, "Usage: %s <mode> <value>\n", argv[0]);
         return -1;
     }
     int mode = atoi(argv[1]);
     int enabled = atoi(argv[2]);
-    if (mode < 0 || mode > 20) return -1;
-    if (enabled != 0 && enabled != 1) return -1;
+    if (mode < 0 || mode > Touch_Mode_NUM) return -1;
     int fd = open(TOUCH_DEV_PATH, O_RDWR);
     // Xiaomi has two competing ABIs, no idea how to detect it
     int arg[3] = {TOUCH_ID, mode, enabled};

--- a/phh-prop-handler.sh
+++ b/phh-prop-handler.sh
@@ -62,6 +62,16 @@ xiaomi_toggle_dt2w_ioctl() {
     return 1
 }
 
+xiaomi_toggle_pen_enable() {
+    if [ -c "/dev/xiaomi-touch" ]; then
+        echo "Trying Enable Xiaomi Smart Pen with ioctl on xiaomi-touch"
+        # 20 - Touch_Pen_ENABLE
+        xiaomi-touch 20 "$1"
+        return
+    fi
+    return 1
+}
+
 restartAudio() {
     setprop ctl.restart audioserver
     audioHal="$(getprop |sed -nE 's/.*init\.svc\.(.*audio-hal[^]]*).*/\1/p')"
@@ -97,6 +107,11 @@ if [ "$1" == "persist.sys.phh.xiaomi.dt2w" ]; then
     xiaomi_toggle_dt2w_event_node "$prop_value"
     # Fallback to ioctl method
     xiaomi_toggle_dt2w_ioctl "$prop_value"
+    exit
+fi
+
+if [ "$1" == "persist.sys.phh.xiaomi.pen" ]; then
+    xiaomi_toggle_pen_enable "$prop_value"
     exit
 fi
 

--- a/vndk.rc
+++ b/vndk.rc
@@ -46,6 +46,9 @@ on property:persist.sys.phh.transsion.dt2w=*
 on property:persist.sys.phh.xiaomi.dt2w=*
     exec u:r:phhsu_daemon:s0 root -- /system/bin/phh-prop-handler.sh "persist.sys.phh.xiaomi.dt2w"
 
+on property:persist.sys.phh.xiaomi.pen=*
+    exec u:r:phhsu_daemon:s0 root -- /system/bin/phh-prop-handler.sh "persist.sys.phh.xiaomi.pen"
+
 on property:persist.sys.phh.allow_binder_thread_on_incoming_calls=*
     exec u:r:phhsu_daemon:s0 root -- /system/bin/phh-prop-handler.sh "persist.sys.phh.allow_binder_thread_on_incoming_calls"
 


### PR DESCRIPTION
TouchFeature: setModeValue mode:20, value:18
[   28.833050] xiaomi_touch_dev_open
[   28.833056] xiaomi_touch_dev_ioctl cmd:0, mode:20, value:18
[   28.833058] [NVT-ts] nvt_set_cur_value 2334: mode:20, value:18
[   28.833059] [NVT-ts] nvt_set_cur_value 2342: ENABLE pen input dev
[   28.872785] [mi_touch]: pen_active = 0
[   56.316567] [mi_touch]: pen_active = 1



Change-Id: I000f4522e9148cdde023e53168549a3f1f1e2100