### PR TITLE
Move TrebleApp allow-in-power-save to sysconfig

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -194,7 +194,8 @@ PRODUCT_PACKAGES += \
 
 # Privapp-permissions whitelist for PhhTrebleApp
 PRODUCT_COPY_FILES += \
-	device/phh/treble/privapp-permissions-me.phh.treble.app.xml:system/etc/permissions/privapp-permissions-me.phh.treble.app.xml
+	device/phh/treble/privapp-permissions-me.phh.treble.app.xml:system/etc/permissions/privapp-permissions-me.phh.treble.app.xml \
+	device/phh/treble/sysconfig-me.phh.treble.app.xml:system/etc/sysconfig/sysconfig-me.phh.treble.app.xml
 
 # Remote debugging
 PRODUCT_COPY_FILES += \

--- a/privapp-permissions-me.phh.treble.app.xml
+++ b/privapp-permissions-me.phh.treble.app.xml
@@ -7,7 +7,4 @@
 	    <permission name="android.permission.INTERACT_ACROSS_USERS"/>
 	    <permission name="android.permission.REQUEST_INSTALL_PACKAGES"/>
     </privapp-permissions>
-
-    <!-- fix voice channels in calls (stop unloading treble-app) -->
-    <allow-in-power-save package="me.phh.treble.app" />
 </permissions>

--- a/sysconfig-me.phh.treble.app.xml
+++ b/sysconfig-me.phh.treble.app.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<config>
+
+	<!-- fix voice channels in calls (stop unloading treble-app) -->
+	<allow-in-power-save package="me.phh.treble.app" />
+
+</config>


### PR DESCRIPTION
Isn't parsed as permissions anymore, now belongs to <config>