### PR TITLE
Rebecco K70 | Change default orientation

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1225,5 +1225,10 @@ if [ -n "$(getprop ro.vendor.transsion.backlight_12bit)" ];then
     setprop ro.vendor.transsion.backlight_hal.optimization $(getprop ro.vendor.transsion.backlight_12bit)
 fi
 
+# Fix default orientation on Rebecco K70
+if getprop ro.vendor.build.fingerprint | grep -iq -e Rebecco/K70_ROW; then
+    resetprop_phh ro.surface_flinger.primary_display_orientation ORIENTATION_0
+fi
+
 # Enable pen mode on Lenovo/goodix
 echo 1 > /sys/devices/platform/goodix_ts.0/support_pen


### PR DESCRIPTION
Otherwise, touch is rotated by 90°. However, this will cause the automatic rotation be reversed.