### PR TITLE
sepolicy: Fix boot on the Galaxy A20s

### DIFF
--- a/sepolicy/samsung.te
+++ b/sepolicy/samsung.te
@@ -20,3 +20,5 @@ allow kernel tmpfs:file relabelfrom;
 
 type sysfs_ski_display_writable, file_type;
 allow platform_app sysfs_ski_display_writable:file r_file_perms;
+
+allow apexd sysfs_mmc_host:file write;


### PR DESCRIPTION
The A20s' vendor wrongly labels "/sys/devices/virtual/block/dm-[0-9]+/queue/read_ahead_kb" as "sysfs_mmc_host", causing a bootloop with the reason "netbpfload-missing".

Since Samsung might have labeled it that way for a reason, fix the problematic denial instead.