### PR TITLE
Add sepolicy for lenovo Y700 gen3/gen4 stylus and d2tw support

### DIFF
--- a/sepolicy/lenovo.te
+++ b/sepolicy/lenovo.te
@@ -1,4 +1,15 @@
 type sysfs_tp, file_type;
+type proc_touch_wake, file_type;
+type proc_support_pen, file_type;
+type proc_high_report_rate, file_type;
 
 #Allow treble_app access to /sys/devices/virtual/touch/tp_dev/gesture_on
 allow system_app sysfs_tp:file rw_file_perms;
+
+# Y700 gen4
+allow system_app proc_touch_wake:file rw_file_perms;
+allow system_app proc_support_pen:file rw_file_perms;
+allow system_app proc_high_report_rate:file rw_file_perms;
+
+# Y700 2025 (gen3)
+allow system_app proc:file rw_file_perms;


### PR DESCRIPTION
Add missing sepolicy for Y700 gen3/gen4 stylus and d2tw support.

Support in TrebleApp is already done on this commit. But it was not working because of missing sepolicy configuration.
https://github.com/TrebleDroid/treble_app/commit/e596f7e859ea6778755086ba49096957d1a3f81a