### PR TITLE
Bluetooth audio fix for Lenovo Y700 gen4 (TB322FC). [2/3]

### DIFF
--- a/phh-prop-handler.sh
+++ b/phh-prop-handler.sh
@@ -68,6 +68,8 @@ restartAudio() {
     setprop ctl.restart "$audioHal"
     setprop ctl.restart vendor.audio-hal-2-0
     setprop ctl.restart audio-hal-2-0
+    setprop ctl.restart vendor.audio-hal-aidl
+    setprop ctl.restart vendor.bluetooth-aidl-qti
 }
 
 if [ "$1" == "persist.sys.phh.asus.dt2w" ]; then
@@ -276,8 +278,34 @@ if [ "$1" == "persist.bluetooth.system_audio_hal.enabled" ]; then
     else
         resetprop_phh --delete persist.bluetooth.bluetooth_audio_hal.disabled
         resetprop_phh --delete persist.bluetooth.a2dp_offload.disabled
-        resetprop_phh --delete ro.bluetooth.a2dp_offload.supported
+        if [ "$(getprop persist.bluetooth.enable_bt_offload)" == "true" ]; then
+            resetprop_phh ro.bluetooth.a2dp_offload.supported true
+        else
+            resetprop_phh --delete ro.bluetooth.a2dp_offload.supported
+        fi
     fi
     restartAudio
+    exit
+fi
+
+if [ "$1" == "persist.bluetooth.enable_bt_offload" ]; then
+    current="$(getprop ro.bluetooth.a2dp_offload.supported)"
+    if [ "$current" = "" ]; then
+        current=true
+    fi
+    # Only update prop if really changed to avoid unneccesary audio restart.
+    if [ "$current" != "$prop_value" ]; then
+        # It is meaningless to apply value if sysbta is enable.
+        if [ "$(getprop persist.bluetooth.system_audio_hal.enabled)" = "false" ]; then
+            if [ "$current" = "true" ]; then
+                resetprop_phh ro.bluetooth.a2dp_offload.supported true
+            else
+                resetprop_phh --delete ro.bluetooth.a2dp_offload.supported
+            fi
+
+            restartAudio
+        fi
+    fi
+
     exit
 fi

--- a/system.prop
+++ b/system.prop
@@ -30,6 +30,8 @@ bluetooth.device.class_of_device=90,2,12
 
 # Enable system-side generic bluetooth audio HAL
 persist.bluetooth.system_audio_hal.enabled=true
+# Use bluetooth A2DP offload for Lenovo/TB322FC (controlled by treble app)
+persist.bluetooth.enable_bt_offload=false
 # Set commonly-supported Bluetooth profiles to enabled
 # TODO: Enable BLE Audio profiles on newer vendors
 bluetooth.profile.asha.central.enabled?=true

--- a/vndk.rc
+++ b/vndk.rc
@@ -72,6 +72,9 @@ on property:ro.sf.lcd_density=*
 on property:persist.bluetooth.system_audio_hal.enabled=*
     exec u:r:phhsu_daemon:s0 root -- /system/bin/phh-prop-handler.sh "persist.bluetooth.system_audio_hal.enabled"
 
+on property:persist.bluetooth.enable_bt_offload=*
+    exec u:r:phhsu_daemon:s0 root -- /system/bin/phh-prop-handler.sh "persist.bluetooth.enable_bt_offload"
+
 on property:init.svc.ril-proxy=stopped && property:persist.sys.phh.restart_ril=true
     start ril-proxy
 


### PR DESCRIPTION
This is a part of patch series to fix bluetooth audio Lenovo Y700 gen4 (TB322FC).

Apply changes for persist.bluetooth.enable_bt_offload which is set by TrebleApp into ro.bluetooth.a2dp_offload.supported.

First part:
https://github.com/TrebleDroid/treble_app/pull/49