### PR TITLE
fix: add keylayout for Lenovo TB710FU smart cover (hall_irq)

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -136,7 +136,8 @@ PRODUCT_COPY_FILES += \
     device/phh/treble/files/moto-liber-gpio-keys.kl.raw:system/phh/moto-liber-gpio-keys.kl \
     device/phh/treble/files/tecno-touchpanel.kl.raw:system/phh/tecno-touchpanel.kl \
     device/phh/treble/files/samsung-sec_e-pen.idc:system/usr/idc/sec_e-pen.idc \
-    device/phh/treble/files/rosemary-excluded-input-devices.xml:system/phh/rosemary-excluded-input-devices.xml
+    device/phh/treble/files/rosemary-excluded-input-devices.xml:system/phh/rosemary-excluded-input-devices.xml \
+    device/phh/treble/files/lenovo-tb710fu-hall_irq.kl.raw:system/phh/lenovo-tb710fu-hall_irq.kl \
 
 SELINUX_IGNORE_NEVERALLOWS := true
 

--- a/base.mk
+++ b/base.mk
@@ -137,7 +137,7 @@ PRODUCT_COPY_FILES += \
     device/phh/treble/files/tecno-touchpanel.kl.raw:system/phh/tecno-touchpanel.kl \
     device/phh/treble/files/samsung-sec_e-pen.idc:system/usr/idc/sec_e-pen.idc \
     device/phh/treble/files/rosemary-excluded-input-devices.xml:system/phh/rosemary-excluded-input-devices.xml \
-    device/phh/treble/files/lenovo-tb710fu-hall_irq.kl.raw:system/phh/lenovo-tb710fu-hall_irq.kl \
+    device/phh/treble/files/lenovo-tb710fu-hall_irq.kl.raw:system/phh/lenovo-tb710fu-hall_irq.kl
 
 SELINUX_IGNORE_NEVERALLOWS := true
 

--- a/files/lenovo-tb710fu-hall_irq.kl.raw
+++ b/files/lenovo-tb710fu-hall_irq.kl.raw
@@ -1,0 +1,3 @@
+# Lenovo TB710FU Hall Effect Sensor Mapping
+key 252 SLEEP
+key 253 WAKEUP

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -240,6 +240,12 @@ changeKeylayout() {
         changed=true
     fi
 
+    if getprop ro.vendor.build.fingerprint | grep -iq -e Lenovo/TB710FU; then
+        cp /system/phh/lenovo-tb710fu-hall_irq.kl /mnt/phh/keylayout/hall_irq.kl
+        chmod 0644 /mnt/phh/keylayout/hall_irq.kl
+        changed=true
+    fi
+
     if ( getprop ro.build.overlay.deviceid |grep -q -e RMX1931 -e RMX1941 -e CPH1859 -e CPH1861 -e RMX2185) ||
 	    ( grep -q OnePlus /odm/etc/$(getprop ro.boot.prjname)/*.prop);then
 	echo 1 > /proc/touchpanel/double_tap_enable

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -240,10 +240,19 @@ changeKeylayout() {
         changed=true
     fi
 
+# --- LENOVO TB710FU / XIAOXIN GT PRO FIXES ---
     if getprop ro.vendor.build.fingerprint | grep -iq -e Lenovo/TB710FU; then
+        
+        # 1. Hardware translation for the magnetic smart cover (hall_irq)
         cp /system/phh/lenovo-tb710fu-hall_irq.kl /mnt/phh/keylayout/hall_irq.kl
         chmod 0644 /mnt/phh/keylayout/hall_irq.kl
         changed=true
+        
+        # 2. Force Tablet UI Characteristics (Taskbar, Split-screen)
+        resetprop_phh ro.build.characteristics tablet
+        
+        # 3. Fix sideways boot animation
+        resetprop_phh ro.bootanim.set_orientation_logical_0 ORIENTATION_90
     fi
 
     if ( getprop ro.build.overlay.deviceid |grep -q -e RMX1931 -e RMX1941 -e CPH1859 -e CPH1861 -e RMX2185) ||


### PR DESCRIPTION
On the Lenovo TB710FU, the kernel registers the magnetic case/smart cover sensor as an input device named hall_irq.
Instead of sending a standard SW_LID event, it sends proprietary key scan codes: 252 when the case is closed, and 253 when the case is opened.

- Added lenovo-tb710fu-hall_irq.kl.raw to map key 252 to SLEEP and key 253 to WAKEUP.
- Appended the raw file to PRODUCT_COPY_FILES.
- Added a fingerprint detection block in rw-system.sh to copy and bind-mount the file as /system/usr/keylayout/hall_irq.kl specifically for the Lenovo TB710FU.