### PR TITLE
Samsung: relax mremap seccomp rule for sw codec2 service

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1248,3 +1248,18 @@ fi
 
 # Enable pen mode on Lenovo/goodix
 echo 1 > /sys/devices/platform/goodix_ts.0/support_pen
+
+# Samsung's sw Codec2 service seccomp policy only allows mremap with
+# MREMAP_MAYMOVE|MREMAP_FIXED, but the current bionic allocator uses other
+# flag combinations, so the service is killed with SIGSYS before it can
+# register android.hardware.media.c2@1.0. The vendor manifest declares that
+# HAL, so MediaCodecList clients wait for it forever, which also wedges the
+# StorageManagerService handler thread at boot and leaves internal storage
+# unmounted. Seen on gts6lwifi (Tab S6), likely other Samsungs too.
+if grep -q '^mremap: arg3 == 3$' /vendor/etc/seccomp_policy/samsung.software.media.c2-base-policy 2>/dev/null; then
+    cp /vendor/etc/seccomp_policy/samsung.software.media.c2-base-policy /mnt/phh/
+    sed -i 's/^mremap: arg3 == 3$/mremap: 1/' /mnt/phh/samsung.software.media.c2-base-policy
+    mount -o bind /mnt/phh/samsung.software.media.c2-base-policy /vendor/etc/seccomp_policy/samsung.software.media.c2-base-policy
+    chcon -h u:object_r:vendor_configs_file:s0 /vendor/etc/seccomp_policy/samsung.software.media.c2-base-policy
+    chmod 644 /vendor/etc/seccomp_policy/samsung.software.media.c2-base-policy
+fi


### PR DESCRIPTION
On my Galaxy Tab S6 (gts6lwifi, stock Samsung vendor) Android 16 GSIs boot with internal storage completely broken: /storage/emulated never mounts, the Files app is empty, screenshots fail and Settings > Storage crashes. Software codecs are broken too. I spent a while chasing this and it turned out to be a seccomp problem in the Samsung vendor image, not a storage bug at all.

What happens:

1. samsung.software.media.c2@1.0-service is killed by seccomp as soon as it starts. The vendor policy has `mremap: arg3 == 3`, which only allows mremap with MREMAP_MAYMOVE|MREMAP_FIXED. The bionic allocator in current GSIs calls mremap with other flags, so the service dies with SIGSYS. init logged 29 kills of it in a single boot on my device.
2. The vendor VINTF manifest declares android.hardware.media.c2@1.0::IComponentStore/default, so MediaCodecList clients wait for the store forever instead of skipping it.
3. On Android 16, StorageManagerService.handleSystemReady() calls configureTranscoding(), which calls isHevcDecoderSupported(), which builds a MediaCodecList. That call never returns. It runs on the StorageManagerService handler thread, which the watchdog does not monitor, so the thread just stays stuck. Everything queued behind it (boot completed handling, volume mounts, completeUnlockUser) never runs, and getVolumeList reports "unmounted due to system locked" forever.

Stack of the stuck thread from a bugreport:

```
"StorageManagerService" prio=5 tid=92 Native
  at android.media.MediaCodecList.native_getCodecCount(Native method)
  at android.media.MediaCodecList.initCodecList(MediaCodecList.java:81)
  at android.media.MediaCodecList.<init>(MediaCodecList.java:172)
  at com.android.server.StorageManagerService.isHevcDecoderSupported(StorageManagerService.java:1008)
  at com.android.server.StorageManagerService.configureTranscoding(StorageManagerService.java:1027)
  at com.android.server.StorageManagerService.handleSystemReady(StorageManagerService.java:975)
```

Relaxing the rule to `mremap: 1` fixes all of it: the c2 service stays up, codecs register, boot completes and storage mounts normally. Verified on my tablet (stock One UI vendor plus MisterZtr lineage 23.2 GSI from 2026.05.24): "System unlocked users" goes from [] to [0], /storage/emulated mounts and sw codecs work.

The change uses the same pattern as the existing motorola/liber audio policy fix in this script: copy the policy to /mnt/phh, patch it, bind mount it over the original. It is guarded by a grep for the exact original line, so it does nothing on vendors that ship a different policy.
